### PR TITLE
Add observer pattern definition to READ ME. #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,31 @@ A multi-language library containing implementations of common software design an
 
 
 ## Table of Contents
+- [Observer Pattern Definition](#observer-pattern)
+
+
+
+
+
+<a id="observer-pattern"></a>
+
+### Definition of Observer Pattern
+
+The observer pattern is a behavioral design pattern often used in software development. 
+
+The purpose of the observer pattern is to establish a one-to-many dependencybetween objects. An object known as the subject maintains a list of it's dependents, called observers. The subject automatically notifies these observers of any state changes it undergoes, typically achieved by invoking one of their methods.
+
+This pattern is often employed in software systems to ensure consistency among multiple components or to notify interested parties about specific events.
+
+As an example, consider a scenario using the analogy of a publisher/subscriber relationship. In this analogy, the publisher acts as the subject, while the subscribers represent the observers. Whenever a significant event occurs to the publisher, it notifies the subscribers by invoking specific notification methods on their objects. This process ensures that subscribers are quickly informed of important updates.
+
+#### References
+
+Design Patterns and Refactoring. (n.d.). Sourcemaking.com. https://sourcemaking.com/design_patterns/observer
+
+Refactoring Guru. (2014). Observer. Refactoring.guru. https://refactoring.guru/design-patterns/observer
+
+Observer pattern. (2022, November 13). Wikipedia. https://en.wikipedia.org/wiki/Observer_pattern#:~:text=In%20software%20design%20and%20engineering
 
 
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A multi-language library containing implementations of common software design an
 
 The observer pattern is a behavioral design pattern often used in software development. 
 
-The purpose of the observer pattern is to establish a one-to-many dependencybetween objects. An object known as the subject maintains a list of it's dependents, called observers. The subject automatically notifies these observers of any state changes it undergoes, typically achieved by invoking one of their methods.
+The purpose of the observer pattern is to establish a one-to-many dependency between objects. An object known as the subject maintains a list of it's dependents, called observers. The subject automatically notifies these observers of any state changes it undergoes, typically achieved by invoking one of their methods.
 
 This pattern is often employed in software systems to ensure consistency among multiple components or to notify interested parties about specific events.
 


### PR DESCRIPTION
I have added the definition for the observer pattern to the README. I have also created a little formatting for the table of contents to make it easier to add more definitions in the future. I may not be aware of best practice or intentions with the table of contents organization so please feel free to make those changes or instruct me and I can do so myself!